### PR TITLE
Pick with most outgoing connections

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -419,10 +419,34 @@ namespace smt::noodler {
                 return l_true;
             }
 
-            // we will now process one inclusion from the inclusion graph which is at front
+            // we will now process one inclusion from the inclusion graph
+            // we will pick and pop the inclusion which has the most outgoing connections
             // i.e. we will update automata assignments and substitutions so that this inclusion is fulfilled
-            Predicate predicate_to_process = element_to_process.predicates_to_process.front();
-            element_to_process.predicates_to_process.pop_front();
+            unsigned max_connections = 0;
+            unsigned max_connections_idx = 0;
+            for (size_t candidate_idx = 0; candidate_idx < element_to_process.predicates_to_process.size(); candidate_idx++)
+            {
+                auto candidate = element_to_process.predicates_to_process[candidate_idx];
+                unsigned current_connections = 0;
+                for (size_t incl_idx = 0; incl_idx < element_to_process.predicates_to_process.size(); incl_idx++)
+                {
+                    if (candidate_idx == incl_idx) continue;
+                    auto incl = element_to_process.predicates_to_process[incl_idx];
+                    if (SolvingState::is_dependent(candidate.get_left_set(), incl.get_right_set()))
+                    {
+                        current_connections++;
+                    }
+                }
+                if (current_connections > max_connections)
+                {
+                    max_connections = current_connections;
+                    max_connections_idx = candidate_idx;
+                }
+            }
+
+            Predicate predicate_to_process = element_to_process.predicates_to_process[max_connections_idx];
+            element_to_process.predicates_to_process[max_connections_idx] = element_to_process.predicates_to_process.back();
+            element_to_process.predicates_to_process.pop_back();
 
             if (predicate_to_process.is_equation()) { // inclusion
                 process_inclusion(predicate_to_process, element_to_process);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -428,11 +428,10 @@ namespace smt::noodler {
             {
                 auto candidate = element_to_process.predicates_to_process[candidate_idx];
                 unsigned current_connections = 0;
-                for (size_t incl_idx = 0; incl_idx < element_to_process.predicates_to_process.size(); incl_idx++)
+                auto left_vars = candidate.get_left_set();
+                for (auto incl : element_to_process.inclusions)
                 {
-                    if (candidate_idx == incl_idx) continue;
-                    auto incl = element_to_process.predicates_to_process[incl_idx];
-                    if (SolvingState::is_dependent(candidate.get_left_set(), incl.get_right_set()))
+                    if (SolvingState::is_dependent(left_vars, incl.get_right_set()))
                     {
                         current_connections++;
                     }


### PR DESCRIPTION
When processing inclusions from the inclusion graph, the one with the most outgoing connections in the inclusion graph will be selected instead of the first one in the queue

```
# of formulae: 16968
--------------------------------------------------
tool                           ✅    ❌     time    avg    med    std    sat    unsat    unknown    TO    MO+ERR    other
--------------------------  -----  ----  -------  -----  -----  -----  -----  -------  ---------  ----  --------  -------
z3-noodler-22e48f3 (base)   16807   161  9513.64   0.57   0.06   2.95   2486    14321        117    44         0        0
z3-noodler-1938a38 (PR)     16801   167  9390.80   0.56   0.06   2.44   2480    14321        117    50         0        0
--------------------------------------------------
```

<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/e474d3cb-9bf5-4b3d-adf2-702183704ddb" />
